### PR TITLE
bugfix: userInfo query 미갱신 이슈

### DIFF
--- a/src/app/summoner-page/_components/summoner-content.tsx
+++ b/src/app/summoner-page/_components/summoner-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 
 import { fetchUserInfo } from "@/lib/fetch-func";
@@ -12,7 +12,7 @@ export const SummonerContent = () => {
   const searchParams = useSearchParams();
   const id = searchParams.get("id") ?? "";
   const tag = searchParams.get("tag") ?? "";
-  const { error, isFetching } = useSuspenseQuery({
+  const { error, isFetching } = useQuery({
     queryKey: [QUERY_KEY.userInfo, { id, tag }],
     queryFn: fetchUserInfo,
   });


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항

<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->

userInfo query에서 useSuspenseQuery, useQuery 둘다 같은 querykey를 사용했음. 허나 둘은 따로 캐싱되므로 refetch해도 리렌더링 되지 않는 이슈 발생함.
- 이전에 suspense를 page.tsx의 파일안 suspense 안에서 사용하기 위해 useSuspenseQuery를 사용했음. 이를 이전 #53 에서 수정했으므로 useSuspenseQuery를 일반 useQuery로 수정해서 query state 동기화함

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->

closes: #59 

